### PR TITLE
transform-functions-qualified-org

### DIFF
--- a/modules/functions/pages/index.adoc
+++ b/modules/functions/pages/index.adoc
@@ -1,11 +1,13 @@
-= Transform Functions 
+= Transform Functions
 
 A Pulsar *transform function* is a low-code implementation of xref:astra-streaming:developing:astream-functions.adoc[Pulsar functions]. +
 Functions receive data from one or more input topics, apply user-supplied processing, and publish the results to another topic. +
 Custom functions are a powerful feature, but for common data transformations, we now include *Transform Functions*. +
 <<Drop-fields>>, <<Flatten>>, <<Compute>>, and more without coding or deep schema knowledge. +
-DataStax has created the following transform functions for common data transforms, but we're always experimenting with new ones. 
-Check back as the list grows, or let us know some functions you'd find helpful in your deployment. 
+DataStax has created the following transform functions for common data transforms, but we're always experimenting with new ones.
+Check back as the list grows, or let us know some functions you'd find helpful in your deployment.
+
+Unqualified orgs can use transform functions without upgrading to a Pay as You Go plan.
 
 [#transform-list]
 == Transforms
@@ -22,7 +24,7 @@ include::partial$/configuration.adoc[]
 include::partial$/deploy-cli.adoc[]
 
 [#deploy-as]
-== Deploy with {product_name} 
+== Deploy with {product_name}
 
 include::partial$/deploy-as.adoc[]
 


### PR DESCRIPTION
Note that transform functions are allowed without a qualified org. 